### PR TITLE
add a validation to additionalinformation field to maximum length of …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
       "drupal/core": {
         "Drupal Core AJAX error fix": "https://www.drupal.org/files/issues/drupal-2027059-62.patch",
         "Number Decimals fields fixed" : "https://www.drupal.org/files/issues/2230909-78-simple_decimals_fail_to.patch"
+      },
+      "drupal/addressfield_cr": {
+        "Change length additionalinformation length": "patches/20180830-correction_characters.patch"
       }
     }
   }

--- a/modules/customer_entity/src/Form/CustomerEntityForm.php
+++ b/modules/customer_entity/src/Form/CustomerEntityForm.php
@@ -104,6 +104,13 @@ class CustomerEntityForm extends ContentEntityForm {
     if ($count > 0 && $count < 5) {
       $form_state->setErrorByName($address, $this->t('If you are going to add the address information, please fill all the fields relate it.'));
     }
+
+    $additionalInfo = $form_state->getValue($address);
+
+    if(strlen($additionalInfo[0]['additionalinfo']) > 160){
+      $form_state->setErrorByName('additionalinfo', $this->t('The additional information field need to have a maximum length of 160 characters.'));
+    }
+
     parent::validateForm($form, $form_state);
   }
 

--- a/patches/20180830-correction_characters.patch
+++ b/patches/20180830-correction_characters.patch
@@ -1,0 +1,29 @@
+diff --git a/src/Plugin/Field/FieldType/addressfield_crItem.php b/src/Plugin/Field/FieldType/addressfield_crItem.php
+index a5fed4b..8dbb8b6 100644
+--- a/src/Plugin/Field/FieldType/addressfield_crItem.php
++++ b/src/Plugin/Field/FieldType/addressfield_crItem.php
+@@ -44,7 +44,7 @@ class addressfield_crItem extends FieldItemBase {
+         ],
+         'additionalinfo' => [
+           'type' => 'varchar',
+-          'length' => 40,
++          'length' => 160,
+         ],
+       ],
+     ];
+diff --git a/src/Plugin/Field/FieldWidget/addressfield_crWidget.php b/src/Plugin/Field/FieldWidget/addressfield_crWidget.php
+index 2f16eaa..2f6d195 100644
+--- a/src/Plugin/Field/FieldWidget/addressfield_crWidget.php
++++ b/src/Plugin/Field/FieldWidget/addressfield_crWidget.php
+@@ -343,9 +343,9 @@ class addressfield_crWidget extends WidgetBase implements WidgetInterface {
+    */
+   public function generateAdditionalInfoField() {
+     return [
+-      '#type' => 'textfield',
++      '#type' => 'textarea',
+       '#title' => t('Additional Information'),
+-      '#size' => 40,
++      '#col' => 160,
+       '#required' => FALSE,
+     ];
+   }


### PR DESCRIPTION
…160 characters

Se creó un parche para el módulo contribuido "accessfield_cr", para que modifique automáticamente a la hora de instalar el módulo, el tamaño máximo de caracteres permitidos a 160, cantidad establecida por el Ministerio de Hacienda para el campo de información adicional.
Además, se creó una validación en CustomerEntityForm::validateForm, para que no permita hacer un submit cuando ese campo tenga una cantidad mayor a 160 caracteres.