### PR TITLE
change the field_quantity type for decimal in invoice entity

### DIFF
--- a/modules/invoice_entity/config/install/field.field.paragraph.invoice_row.field_quantity.yml
+++ b/modules/invoice_entity/config/install/field.field.paragraph.invoice_row.field_quantity.yml
@@ -24,4 +24,4 @@ settings:
   max: null
   prefix: ''
   suffix: ''
-field_type: integer
+field_type: decimal

--- a/modules/invoice_entity/config/install/field.storage.paragraph.field_quantity.yml
+++ b/modules/invoice_entity/config/install/field.storage.paragraph.field_quantity.yml
@@ -10,7 +10,7 @@ dependencies:
 id: paragraph.field_quantity
 field_name: field_quantity
 entity_type: paragraph
-type: integer
+type: decimal
 settings:
   unsigned: false
   size: normal


### PR DESCRIPTION
Para el módulo invoice_entity, se modificó el campo Cantidad, ya que según lo establecido por el Ministerio de Hacienda, este campo es un número decimal compuesto por 13 enteros y 3 decimales, por lo que el tipo de ese campo se cambió de entero a decimal.
Esto se llevó a cabo en los archivos del config/install: field.field.paragraph.invoice_row.field_quantity.yml y field.storage.paragraph.field_quantity.yml