### PR TITLE
Resolved: Problemas para crear facturas

### DIFF
--- a/modules/invoice_entity/src/Form/InvoiceEntityForm.php
+++ b/modules/invoice_entity/src/Form/InvoiceEntityForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\invoice_entity\Form;
 
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
@@ -34,7 +34,7 @@ class InvoiceEntityForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityManagerInterface $entity_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
+  public function __construct(EntityTypeManagerInterface $entity_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
     parent::__construct($entity_manager, $entity_type_bundle_info, $time);
     $settings = \Drupal::config('e_invoice_cr.settings');
     $empty = $settings->isNew();

--- a/modules/invoice_entity/src/Form/InvoiceEntityForm.php
+++ b/modules/invoice_entity/src/Form/InvoiceEntityForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\invoice_entity\Form;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
@@ -34,8 +34,8 @@ class InvoiceEntityForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeManagerInterface $entity_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
-    parent::__construct($entity_manager, $entity_type_bundle_info, $time);
+  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $settings = \Drupal::config('e_invoice_cr.settings');
     $empty = $settings->isNew();
     if ($empty || is_null($settings)) {

--- a/modules/invoice_received_entity/src/Controller/InvoiceReceivedEntityController.php
+++ b/modules/invoice_received_entity/src/Controller/InvoiceReceivedEntityController.php
@@ -131,7 +131,7 @@ class InvoiceReceivedEntityController extends ControllerBase implements Containe
                 'invoice_received_entity' => $invoice_received_entity->id(),
                 'invoice_received_entity_revision' => $vid,
                 'langcode' => $langcode,
-              ])
+              ]):
               Url::fromRoute('entity.invoice_received_entity.revision_revert', [
                 'invoice_received_entity' => $invoice_received_entity->id(),
                 'invoice_received_entity_revision' => $vid,

--- a/modules/invoice_received_entity/src/Controller/InvoiceReceivedEntityController.php
+++ b/modules/invoice_received_entity/src/Controller/InvoiceReceivedEntityController.php
@@ -131,7 +131,7 @@ class InvoiceReceivedEntityController extends ControllerBase implements Containe
                 'invoice_received_entity' => $invoice_received_entity->id(),
                 'invoice_received_entity_revision' => $vid,
                 'langcode' => $langcode,
-              ]):
+              ]) :
               Url::fromRoute('entity.invoice_received_entity.revision_revert', [
                 'invoice_received_entity' => $invoice_received_entity->id(),
                 'invoice_received_entity_revision' => $vid,


### PR DESCRIPTION
En Drupal\\invoice_entity\\Form\\InvoiceEntityForm::__construct() del archivo InvoiceEntityForm.php, se estaba pasando como parámetro una variable de tipo EntityManagerInterface, el cual se encuentra obsoleto. Además, en la version 8.6.x de Drupal se reemplaza como parámetro al tipo EntityRepositoryInterface, por lo que se realizan los cambios respectivos para eliminar ese error.