### PR TITLE
Correccion de errores

### DIFF
--- a/modules/customer_entity/src/Form/CustomerEntityForm.php
+++ b/modules/customer_entity/src/Form/CustomerEntityForm.php
@@ -96,11 +96,14 @@ class CustomerEntityForm extends ContentEntityForm {
       $form_state->setErrorByName($phone, $this->t("The telephone number should only have numbers. No spaces or special characters."));
     }
 
-    $filled_fields = array_filter($form_state->getValue($address)[0], function ($value) {
-      return !empty($value);
-    });
+    $count = 0;
+    if (isset($form_state->getValue($address)[0])){
+      $filled_fields = array_filter($form_state->getValue($address)[0], function ($value) {
+        return !empty($value);
+      });
+      $count = count($filled_fields);
+    }
 
-    $count = count($filled_fields);
     if ($count > 0 && $count < 5) {
       $form_state->setErrorByName($address, $this->t('If you are going to add the address information, please fill all the fields relate it.'));
     }

--- a/modules/customer_entity/src/Form/CustomerEntityForm.php
+++ b/modules/customer_entity/src/Form/CustomerEntityForm.php
@@ -97,7 +97,7 @@ class CustomerEntityForm extends ContentEntityForm {
     }
 
     $count = 0;
-    if (isset($form_state->getValue($address)[0])){
+    if (isset($form_state->getValue($address)[0])) {
       $filled_fields = array_filter($form_state->getValue($address)[0], function ($value) {
         return !empty($value);
       });

--- a/src/Form/InvoiceSettingsForm.php
+++ b/src/Form/InvoiceSettingsForm.php
@@ -303,7 +303,6 @@ class InvoiceSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $values = $form_state->getValues();
     $tabs = $values['settings_tab']['stuff'];
-    $id_type = $tabs['auth_group']['id_type'];
     // Retrieve the configuration.
     \Drupal::configFactory()->getEditable('e_invoice_cr.settings')
       // Set the submitted configuration setting.


### PR DESCRIPTION
Corrección de errores mínimos:
1. Al insertar un cliente solo con los campos requeridos, se mostraba un error ya que se estaba tomando un valor nulo. Se hace una verificación para ver si ese valor existe.
2. Se estaba tratando de asignar a una variable, un valor de un array con un index que no existe. Además, era un valor que no se estaba utilizando, por lo que se elimina esa línea.